### PR TITLE
Fix crash when a keybinding with a category not known to MC gets added

### DIFF
--- a/src/main/java/org/dimdev/rift/listener/client/LocalCommandAdder.java
+++ b/src/main/java/org/dimdev/rift/listener/client/LocalCommandAdder.java
@@ -1,0 +1,8 @@
+package org.dimdev.rift.listener.client;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.command.CommandSource;
+
+public interface LocalCommandAdder {
+    void registerLocalCommands(CommandDispatcher<CommandSource> dispatcher);
+}

--- a/src/main/java/org/dimdev/rift/mixin/hook/client/MixinGuiChat.java
+++ b/src/main/java/org/dimdev/rift/mixin/hook/client/MixinGuiChat.java
@@ -30,12 +30,9 @@ public class MixinGuiChat {
 
     public Object gotServerSideSuggestions(CompletableFuture<Suggestions> pendingSuggestions) {
         Suggestions server=pendingSuggestions.join();
-//        System.out.println("gSSS called, server is " + server);
         Suggestions local=LocalCommandManager.getSuggestions(inputField.getText());
-//        System.out.println("local is " + local);
-//        System.out.println("---------------------------");
-        
-        if (local.isEmpty()) {
+
+        if (local==null || local.isEmpty()) {
             return server;
         }
         

--- a/src/main/java/org/dimdev/rift/mixin/hook/client/MixinGuiChat.java
+++ b/src/main/java/org/dimdev/rift/mixin/hook/client/MixinGuiChat.java
@@ -1,0 +1,57 @@
+package org.dimdev.rift.mixin.hook.client;
+
+import com.mojang.brigadier.suggestion.Suggestion;
+import net.minecraft.client.gui.GuiChat;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import com.mojang.brigadier.suggestion.Suggestions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.client.gui.GuiTextField;
+import org.dimdev.rift.util.LocalCommandManager;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(GuiChat.class)
+public class MixinGuiChat {
+    
+    @Shadow GuiTextField inputField;
+    
+    @Redirect(method="showSuggestions",
+            at=@At(value="INVOKE",
+                   target="Ljava/util/concurrent/CompletableFuture;join()Ljava/lang/Object;",
+                   remap=false)
+            )
+
+    // We need to declare this to return Object, not Suggestions, because the
+    // redirected method is type polymorphic and thus returns Object,
+    // not Suggestions, in its byte code definition.
+
+    public Object gotServerSideSuggestions(CompletableFuture<Suggestions> pendingSuggestions) {
+        Suggestions server=pendingSuggestions.join();
+//        System.out.println("gSSS called, server is " + server);
+        Suggestions local=LocalCommandManager.getSuggestions(inputField.getText());
+//        System.out.println("local is " + local);
+//        System.out.println("---------------------------");
+        
+        if (local.isEmpty()) {
+            return server;
+        }
+        
+        if (server.isEmpty()) {
+            return local;
+        }
+        
+        if (!local.getRange().equals(server.getRange())) {
+            System.err.println("something wrong with ranges");
+            return server;
+        }
+
+        List<Suggestion> results=new ArrayList<>();
+        results.addAll(server.getList());
+        results.addAll(local.getList());
+        Suggestions result=new Suggestions(server.getRange(), results);
+        return result;
+    }
+}

--- a/src/main/java/org/dimdev/rift/mixin/hook/client/MixinKeyBinding.java
+++ b/src/main/java/org/dimdev/rift/mixin/hook/client/MixinKeyBinding.java
@@ -1,0 +1,21 @@
+package org.dimdev.rift.mixin.hook.client;
+
+import java.util.Map;
+import net.minecraft.client.settings.KeyBinding;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(KeyBinding.class)
+public class MixinKeyBinding {
+    @Shadow private static Map<String, Integer> CATEGORY_ORDER;
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void insertCategory(String description,
+            int keycode, String category, CallbackInfo ci) {
+        if (CATEGORY_ORDER.get(category)==null) {
+            CATEGORY_ORDER.put(category, CATEGORY_ORDER.size());
+        }
+    }
+}

--- a/src/main/java/org/dimdev/rift/mixin/hook/client/MixinLocalCommand.java
+++ b/src/main/java/org/dimdev/rift/mixin/hook/client/MixinLocalCommand.java
@@ -1,0 +1,25 @@
+package org.dimdev.rift.mixin.hook.client;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.client.entity.EntityPlayerSP;
+import org.dimdev.rift.util.LocalCommandManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityPlayerSP.class)
+public class MixinLocalCommand {
+    @Inject(method="sendChatMessage", at=@At("HEAD"), cancellable=true)
+    private void handleLocalCommand(String message, CallbackInfo callbackInfo) {
+        if (message.startsWith("/")) {
+            try {
+                LocalCommandManager.dispatchLocalCommand(message.substring(1));
+                callbackInfo.cancel();
+            } catch (CommandSyntaxException ex) {
+                // Don't do anything, it wasn't intended to be our command.
+                // Not cancelling callbackInfo will make MC send the command to the server.
+            }
+        }
+    }
+}

--- a/src/main/java/org/dimdev/rift/util/LocalCommandManager.java
+++ b/src/main/java/org/dimdev/rift/util/LocalCommandManager.java
@@ -1,0 +1,64 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.dimdev.rift.util;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.ParseResults;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.Suggestions;
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.command.CommandSource;
+import org.dimdev.rift.listener.client.LocalCommandAdder;
+import org.dimdev.riftloader.RiftLoader;
+
+/**
+ *
+ * @author gbl
+ */
+public class LocalCommandManager {
+    
+    private static LocalCommandManager instance;
+    private CommandDispatcher<CommandSource> dispatcher;
+    private CompletableFuture<Suggestions> suggestions;
+
+    private LocalCommandManager() {
+    }
+    
+    public static LocalCommandManager getInstance() {
+        if (instance == null) {
+            instance=new LocalCommandManager();
+            instance.dispatcher=new CommandDispatcher<>();
+            
+            for (LocalCommandAdder localCommandAdder: RiftLoader.instance.getListeners(LocalCommandAdder.class)) {
+                localCommandAdder.registerLocalCommands(instance.dispatcher);
+            }
+        }
+        return instance;
+    }
+    
+    public static void dispatchLocalCommand(String s) throws CommandSyntaxException {
+        getInstance().dispatcher.execute(s, null);
+    }
+    
+    private Suggestions getSuggestionsFor(String command) {
+        // Don't just pass command; pass a stringreader that skips over the '/',
+        // or Suggestions.range won't match the server version.
+        StringReader reader=new StringReader(command);
+        reader.skip();
+        ParseResults<CommandSource> parse = dispatcher.parse(reader, null);
+        // We are losing the advantage of using a separate thread here,
+        // but the server commands, which imply a network exchange,
+        // need it much more than we do.
+        suggestions = dispatcher.getCompletionSuggestions(parse);
+        Suggestions result = suggestions.join();
+        return result;
+    }
+    
+    public static Suggestions getSuggestions(String s) {
+        return getInstance().getSuggestionsFor(s);
+    }
+}

--- a/src/main/java/org/dimdev/rift/util/LocalCommandManager.java
+++ b/src/main/java/org/dimdev/rift/util/LocalCommandManager.java
@@ -45,6 +45,9 @@ public class LocalCommandManager {
     }
     
     private Suggestions getSuggestionsFor(String command) {
+        if (!command.startsWith("/")) {
+		    return null;
+        }
         // Don't just pass command; pass a stringreader that skips over the '/',
         // or Suggestions.range won't match the server version.
         StringReader reader=new StringReader(command);

--- a/src/main/resources/mixins.rift.hooks.json
+++ b/src/main/resources/mixins.rift.hooks.json
@@ -48,6 +48,7 @@
     "client.MixinRenderManager",
     "client.MixinEntityPlayerSP",
     "client.MixinGameSettings",
-    "client.MixinGuiIngame"
+    "client.MixinGuiIngame",
+    "client.MixinKeyBinding"
   ]
 }

--- a/src/main/resources/mixins.rift.hooks.json
+++ b/src/main/resources/mixins.rift.hooks.json
@@ -41,6 +41,8 @@
     "MixinItemTool"
   ],
   "client": [
+    "client.MixinGuiChat",
+    "client.MixinLocalCommand",
     "client.MixinMinecraft",
     "client.MixinModelBakery",
     "client.MixinNetHandlerPlayClient",


### PR DESCRIPTION
When a KeyBinding gets added that uses a category that's unknown to Minecraft, opening the "Controls" option dialog results in a crash.

This is because KeyBinding.java initializes a map (called CATEGORY_ORDER) from category name to a sorting index, and this map doesn't get updated when the KeyBind is added, resulting in an NPE when the GUI actually tries sorting existing indexes.

This patch fixes this behaviour by providing a Mixin that appends the new category name to the CATEGORY_ORDER map whenever a KeyBind with an yet-unknown name gets added.
