### PR TITLE
Add support for mods with no listeners

### DIFF
--- a/src/main/java/org/dimdev/riftloader/ModInfo.java
+++ b/src/main/java/org/dimdev/riftloader/ModInfo.java
@@ -45,4 +45,5 @@ public class ModInfo {
     public String name;
     public List<String> authors = new ArrayList<>();
     public List<Listener> listeners = new ArrayList<>();
+    public List<String> mixins = new ArrayList<>();
 }

--- a/src/main/java/org/dimdev/riftloader/RiftLoader.java
+++ b/src/main/java/org/dimdev/riftloader/RiftLoader.java
@@ -12,6 +12,7 @@ import org.dimdev.riftloader.listener.Instantiator;
 import org.dimdev.utils.InstanceListMap;
 import org.dimdev.utils.InstanceMap;
 import org.dimdev.utils.ReflectionUtils;
+import org.spongepowered.asm.mixin.Mixins;
 
 import java.io.File;
 import java.io.IOException;
@@ -195,6 +196,14 @@ public class RiftLoader {
             listener.onInitialization();
         }
 
+        // Load the mixins
+        for (ModInfo modInfo : modInfoMap.values()) {
+            if (modInfo.mixins != null) {
+                for (String mixin : modInfo.mixins) {
+                    Mixins.addConfigurations(mixin);
+                }
+            }
+        }
         log.info("Done initializing mods");
     }
 


### PR DESCRIPTION
In some cases the only reason for a listener is to allow mixin configuration to be registered.  This change allows for a mod creator to specify the mixin configuration filename(s) and Rift will add them to the configuration.  e.g.

```
{
  "id": "modid",
  "name": "Example mod",
  "authors": [
    "me"
  ],
  "mixins": [
    "mixins.modid.json"
  ]
}
```

Another benefit for doing this is that some vanilla-only mods can use this without having to mess with their existing build.gradle... Just add a riftmod.json and be done.